### PR TITLE
Adds support for more efficient integration domain 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SimpleNonlinearSolve = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ julia> quadts(f, TSQuadrature{Float64}(), -1,1, atol=1e-16)
 ```
 
 Also the transformation now supports higher order of odd powers of the form 
-$$\Psi(t) = Tanh(\frac{\Pi}{2} Sinh(t^p)) $$
+$$\Psi(t) = \Tanh(\frac{\Pi}{2} \Sinh(t^p)) $$
 These are called TSHi where i is 1,3,5... 
 for more details look into this [paper](https://ems.press/content/serial-article-files/2719)
 ``` julia

--- a/README.md
+++ b/README.md
@@ -27,8 +27,20 @@ julia> quadts(f, TSQuadrature{Float64}(), -1,1, atol=1e-16)
 (result = 3.9999999782382543, error = 2.3940849303016876e-12, levels = 20)
 ```
 
+Also the transformation now supports higher order of odd powers of the form 
+$$\Psi(t) = Tanh(\frac{\Pi}{2} Sinh(t^p)) $$
+These are called TSHi where i is 1,3,5... 
+for more details look into this [paper](https://ems.press/content/serial-article-files/2719)
+``` julia
+julia> f(x::T) where T = sqrt(T(2))/sqrt(one(T)+x)
+# 1 is here corresponds to p=1 the usual TSH rule
+julia> quadts(f, TSQuadrature{Float64}(1), -1,1)
+(result = 3.9999999347276813, error = 2.6538651720642292e-8, levels = 6)
 
-
+# 3 here is p=3 (TSH3 rule)
+julia> quadts(f, TSQuadrature{Float64}(3), -1,1, atol=1e-16)
+(result = 3.9999991492059976, error = 8.290316966252931e-7, levels = 20)
+```
 
 ## Related work
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ julia> quadts(f, TSQuadrature{Float64}(3), -1,1, atol=1e-16)
 (result = 3.9999991492059976, error = 8.290316966252931e-7, levels = 20)
 ```
 
+
+## issues
+
+when the function has a singularity at one of the interval points,
+and the interval is small, Underflow happens. As the levels of refinement
+increase, the integration points coincide on t=+-1 and thus evaluate the
+function at the singularity. This should not happen since we explicitly 
+impose conditions to avoid UFL to get the integration domain.
+
+
+
 ## Related work
 
 One-dimensional tanh-sinh quadrature:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,22 @@ Julia
 
 THIS PACKAGE IS INCOMPLETE. DO NOT USE.
 
+I added conditions for the integration range $$[-t_n, t_n]$$ from this [paper](https://arxiv.org/pdf/2007.15057.pdf)
+it gives improved error rates
+
+``` julia
+julia> f(x::T) where T = sqrt(T(2))/sqrt(one(T)+x)
+
+julia> quadts(f, TSQuadrature{Float64}(), -1,1)
+(result = 3.9999999347276813, error = 2.6538651720642292e-8, levels = 6)
+
+julia> quadts(f, TSQuadrature{Float64}(), -1,1, atol=1e-16)
+(result = 3.9999999782382543, error = 2.3940849303016876e-12, levels = 20)
+```
+
+
+
+
 ## Related work
 
 One-dimensional tanh-sinh quadrature:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ julia> quadts(f, TSQuadrature{Float64}(), -1,1, atol=1e-16)
 ```
 
 Also the transformation now supports higher order of odd powers of the form 
-$$\Psi(t) = \Tanh(\frac{\Pi}{2} \Sinh(t^p)) $$
+$$\Psi(t) = \tanh(\frac{\pi}{2} \sinh(t^p)) $$
 These are called TSHi where i is 1,3,5... 
 for more details look into this [paper](https://ems.press/content/serial-article-files/2719)
 ``` julia

--- a/README.md
+++ b/README.md
@@ -48,10 +48,49 @@ julia> quadts(f, TSQuadrature{Float64}(3), -1,1, atol=1e-16)
 when the function has a singularity at one of the interval points,
 and the interval is small, Underflow happens. As the levels of refinement
 increase, the integration points coincide on t=+-1 and thus evaluate the
-function at the singularity. This should not happen since we explicitly 
-impose conditions to avoid UFL to get the integration domain.
+function at the singularity. 
 
+This underflow instability stems from the variable transformation to map an
+arbitrary domain [a,b] to [-1,1]. In the original conditions to avoid underflow 
+instabilities from this [paper](https://arxiv.org/pdf/2007.15057.pdf), the authors
+don't take into account this variable trasformation. We provide a function 
+to find $t_max$ taking into account the variable transformation, but the need to specify
+the domain of integration defeats the design of a reusable {TSQuadrature} object.
 
+A workaround is to use higher order TSHi methods. For example TSH3 works and avoids
+the underflow instability due to the more rapid fall off of the transformed function.
+``` julia
+julia> f(x::T) where T = one(T)/(x-one(T))
+
+# 1 here corresponds to p=1, the original TSH rule
+julia> quad = TSQuadrature{T}(10, 1);
+
+julia> quadts(h, quad, 0,1)
+(-36.64917027223108, 0.09679325694600749, 10)
+
+julia> quadts(h, quad, 0.92,1)
+(-34.66297119486927, 0.01782170555074116, 10)
+
+julia> quadts(h, quad, 0.93,1)
+(Inf, Inf, 6)
+
+# 3 here corresponds to p=3, the TSH3 rule
+julia> quad = TSQuadrature{Float64}(10, 3);
+
+julia> quadts(h, quad, 0,1)
+(-6.440474048946902, 0.005131276307238863, 10)
+
+julia> quadts(h, quad, 0.92,1)
+(-6.44047404894647, 0.005131276307250798, 10)
+
+julia> quadts(h, quad, 0.93,1)
+(-6.440474048947368, 0.0051312763072301915, 10)
+
+julia> quadts(h, quad, 0.999999999,1)
+(-6.440440508722164, 0.0051306262629217175, 10)
+```
+
+TL;DR : if you get Inf use p>=3 (odd)
 
 ## Related work
 

--- a/src/TanhSinhQuadrature.jl
+++ b/src/TanhSinhQuadrature.jl
@@ -74,6 +74,9 @@ transform(u::T, a::T, b::T) where {T} = (b + a) / T(2) + ((b - a) / T(2)) * u
 
 function quadts(f, quad::TSQuadrature{T}, xmin::T, xmax::T; atol::T=zero(T),
                 rtol::T=atol > 0 ? zero(T) : sqrt(eps(T))) where {T<:Real}
+    if xmin == xmax
+        return 0
+    end
     Δx = (xmax - xmin) / 2
     h = quad.h
 

--- a/src/TanhSinhQuadrature.jl
+++ b/src/TanhSinhQuadrature.jl
@@ -159,7 +159,6 @@ function find_tmaxND(D::Int, T::Type, p::Int)
     probN = NonlinearProblem(f, u0)
     tmaxw = solve(probN, SimpleNewtonRaphson(); abstol=eps(T))[1]
     tmax = min(tmaxx, tmaxw)
-    @show tmaxx, tmaxw
     return tmax
 end
 

--- a/src/TanhSinhQuadrature.jl
+++ b/src/TanhSinhQuadrature.jl
@@ -229,15 +229,15 @@ end
 
 export myquad2, myquad3
 function myquad3(f, quad, xmin, xmax)
-    f1(x, y) = quadts(z -> f(x, y, z), quad, xmin[3], xmax[3]).result
-    f2(x) = quadts(y -> f1(x, y), quad, xmin[2], xmax[2]).result
-    f3() = quadts(x -> f2(x), quad, xmin[1], xmax[1]).result
+    f1(x, y) = quadts(z -> f(x, y, z), quad, xmin[3], xmax[3])[1]
+    f2(x) = quadts(y -> f1(x, y), quad, xmin[2], xmax[2])[1]
+    f3() = quadts(x -> f2(x), quad, xmin[1], xmax[1])[1]
     return f3()
 end
 
 function myquad2(f, quad, xmin, xmax)
-    f2(x) = quadts(y -> f(x, y), quad, xmin[2], xmax[2]).result
-    f3() = quadts(x -> f2(x), quad, xmin[1], xmax[1]).result
+    f2(x) = quadts(y -> f(x, y), quad, xmin[2], xmax[2])[1]
+    f3() = quadts(x -> f2(x), quad, xmin[1], xmax[1])[1]
     return f3()
 end
 

--- a/src/TanhSinhQuadrature.jl
+++ b/src/TanhSinhQuadrature.jl
@@ -95,6 +95,7 @@ function quadts(f, quad::TSQuadrature{T}, xmin::T, xmax::T; atol::T=zero(T),
             xm = transform(-p.x, xmin, xmax)
             xp = transform(p.x, xmin, xmax)
             w = p.w
+            # @show xm, xp, f(xm), f(xp), p.x
             s += w * (f(xm) + f(xp))
         end
         s = h * s + sold / 2
@@ -157,7 +158,8 @@ function find_tmaxND(D::Int, T::Type, p::Int)
     u0 = (tmaxx)^(1 / D)
     probN = NonlinearProblem(f, u0)
     tmaxw = solve(probN, SimpleNewtonRaphson(); abstol=eps(T))[1]
-    tmax = min(tmaxx, tmaxw) # min or max?
+    tmax = min(tmaxx, tmaxw)
+    @show tmaxx, tmaxw
     return tmax
 end
 
@@ -231,7 +233,7 @@ function quadts(f, quad::TSQuadratureND{D,T}, xmin::SVector{D,T}, xmax::SVector{
 end
 
 export myquad2, myquad3
-function myquad3(f, quad, xmin, xmax)
+function myquad3(f, quad::TSQuadrature{T}, xmin::AbstractVector{T}, xmax::AbstractVector{T}) where {T<:Real}
     f1(x, y) = quadts(z -> f(x, y, z), quad, xmin[3], xmax[3])[1]
     f2(x) = quadts(y -> f1(x, y), quad, xmin[2], xmax[2])[1]
     f3() = quadts(x -> f2(x), quad, xmin[1], xmax[1])[1]

--- a/src/TanhSinhQuadrature.jl
+++ b/src/TanhSinhQuadrature.jl
@@ -5,7 +5,7 @@ using StaticArrays
 using SimpleNonlinearSolve
 ################################################################################
 
-export TSQuadrature, quadts
+export TSQuadrature, quadts, npoints
 
 # ∫dx f(x) = ∫dt f(t) dx/dt
 #
@@ -28,6 +28,7 @@ struct Level{T}
 end
 
 # A complete quadrature scheme. `h` is the base step size for level 0.
+# h basicaly is tmax for https://arxiv.org/pdf/2007.15057.pdf
 struct TSQuadrature{T}
     h::T
     levels::Vector{Level{T}}
@@ -40,19 +41,26 @@ end
 
 # Find the step size `h` at which a single step suffices to exhaust
 # the numerical precision. Look at https://arxiv.org/pdf/2007.15057.pdf
-find_tmax(T::Type, p::Int) = find_tmaxND(1, T, p)
+find_tmax(::Type{T}, p::Int) where {T} = find_tmaxND(T, 1, p)
+function find_tmaxND(::Type{T}, D::Int, p::Int) where {T}
+    Fmin = eps(T)
+    tmaxx = inv_ordinate(one(T) - Fmin, p)
 
-# w == 0
-# abs(x) == 1
-# is that good?
+    f(x, l) = weight(x, p)^D - Fmin
+    u0 = (tmaxx)^(1 / D)
+    probN = NonlinearProblem(f, u0)
+    # is this maybe responsible for the Inf results for small domains ? Maybe increase the tolerance?
+    tmaxw = solve(probN, SimpleNewtonRaphson(); abstol=eps(T))[1]
+    tmax = min(tmaxx, tmaxw)
+    return tmax
+end
+
 function Level(h::T, n) where {T<:Real}
     points = Point{T}[]
     for i in 0:(2^(n - 1) - 1)
         t = h + i * (2h)
         x = ordinate(t)
         w = weight(t)
-        # i > 0 && abs(x) == 1 && break
-        # i > 0 && w == 0 && break
         push!(points, Point{T}(x, w))
     end
     reverse!(points)            # improve summation accuracy
@@ -69,20 +77,33 @@ function TSQuadrature{T}(nlevels::Int=20, p::Int=1) where {T<:Real}
     return TSQuadrature{T}(h, levels)
 end
 
-# maps [a,b] to [-1,1]
-transform(u::T, a::T, b::T) where {T} = (b + a) / T(2) + ((b - a) / T(2)) * u
+import Base.eltype
+eltype(quad::TSQuadrature{T}) where {T} = T
+eltype(p::Point{T}) where {T} = T
 
-function quadts(f, quad::TSQuadrature{T}, xmin::T, xmax::T; atol::T=zero(T),
-                rtol::T=atol > 0 ? zero(T) : sqrt(eps(T))) where {T<:Real}
-    if xmin == xmax
-        return 0
+import Base.length
+length(quad::TSQuadrature{T}) where {T} = length(quad.levels)
+levels(quad::TSQuadrature{T}) where {T} = length(quad)
+function npoints(quad::TSQuadrature{T}) where {T}
+    points = 0
+    for lvl in quad.levels
+        points += length(lvl.points)
     end
-    Δx = (xmax - xmin) / 2
+    # the +1 is for the point t=0 that is put by hand
+    # before the loop
+    return points + 1
+end
+
+function _quadts(f, quad::TSQuadrature{T}; atol::T=zero(T), rtol::T=atol > 0 ? zero(T) : sqrt(eps(T))) where {T<:Real}
+    # Δx = (xmax - xmin) / 2
     h = quad.h
 
-    x = (xmin + xmax) / 2
+    # x = (xmin + xmax) / 2
+
+    # POINT t=0
     w = weight(zero(T))
-    s = h * w * f(transform(zero(T), xmin, xmax))
+    # s = h * w * f(transform(zero(T), xmin, xmax))
+    s = h * w * f(zero(T))
     levels = 0
     error = T(Inf) # norm(typeof(s)(Inf))
 
@@ -92,11 +113,12 @@ function quadts(f, quad::TSQuadrature{T}, xmin::T, xmax::T; atol::T=zero(T),
         sold = s
         s = zero(sold)
         for p in level.points
-            xm = transform(-p.x, xmin, xmax)
-            xp = transform(p.x, xmin, xmax)
-            w = p.w
+            #xm = transform(-p.x, xmin, xmax)
+            #xp = transform(p.x, xmin, xmax)
+            # w = p.w
             # @show xm, xp, f(xm), f(xp), p.x
-            s += w * (f(xm) + f(xp))
+            # s += w * (f(xm) + f(xp))
+            s += p.w * (f(-p.x) + f(p.x))
         end
         s = h * s + sold / 2
 
@@ -105,154 +127,168 @@ function quadts(f, quad::TSQuadrature{T}, xmin::T, xmax::T; atol::T=zero(T),
         levels ≥ 1 && error ≤ tol && break
     end
 
-    return (result=Δx * s, error=error, levels=levels)
+    # return (result=Δx * s, error=error, levels=levels)
+    return (result=s, error=error, levels=levels)
 end
 
-function quadts(f, quad::TSQuadrature{T}, xmin::Real, xmax::Real; atol::Real=zero(T),
-                rtol::Real=atol > 0 ? zero(T) : sqrt(eps(T))) where {T<:Real}
-    return quadts(f, quad, T(xmin), T(xmax); atol=T(atol), rtol=T(rtol))
-end
-
-################################################################################
-
-export TSQuadratureND
-
-# An integration point, defined by its coordinate `x` and weight `w`
-struct PointND{D,T}
-    x::SVector{D,T}
-    w::T
-end
-
-# We integrate in levels. Each successivel level refines the previous
-# one, and only contains the additional points and weights.
-struct LevelND{D,T}
-    points::Vector{PointND{D,T}}
-end
-
-# A complete quadrature scheme. `h` is the base step size for level 0.
-struct TSQuadratureND{D,T}
-    h::T
-    levels::Vector{LevelND{D,T}}
-end
-
-# is w ≠ 0 ok?
-function LevelND{D,T}(level::Level{T}) where {D,T<:Real}
-    D::Int
-    @assert D ≥ 0
-    points = PointND{D,T}[]
-    npoints = length(level.points)
-    for i in CartesianIndex(ntuple(d -> 1, D)):CartesianIndex(ntuple(d -> npoints, D))
-        x = SVector{D,T}(level.points[Tuple(i)[d]].x for d in 1:D)
-        w = prod(level.points[Tuple(i)[d]].w for d in 1:D)
-        # w ≠ 0 && push!(points, PointND{D,T}(x, w))
-        push!(points, PointND{D,T}(x, w))
-    end
-    return LevelND{D,T}(points)
-end
-
-function find_tmaxND(D::Int, T::Type, p::Int)
-    Fmin = eps(T)
-    tmaxx = inv_ordinate(one(T) - Fmin, p)
-
-    f(x, l) = weight(x, p)^D - Fmin
-    u0 = (tmaxx)^(1 / D)
-    probN = NonlinearProblem(f, u0)
-    tmaxw = solve(probN, SimpleNewtonRaphson(); abstol=eps(T))[1]
-    tmax = min(tmaxx, tmaxw)
-    return tmax
-end
-
-#if I add type in constructor, julia doesn't see the whole function, why?
-function TSQuadratureND{D,T}(nlevels::Int, p::Int=1) where {D,T<:Real}
-    D::Int #why ?
-    @assert D ≥ 0
-
-    h = find_tmaxND(D, T, p)
-    levels = Level{T}[]
-    for level in 1:nlevels
-        push!(levels, Level(h / 2^level, level))
-    end
-    quad = TSQuadrature{T}(h, levels)
-    levels = LevelND{D,T}[]
-    for level in 1:nlevels
-        push!(levels, LevelND{D,T}(quad.levels[level]))
-        npoints = length(levels[end].points)
-    end
-    return TSQuadratureND{D,T}(h, levels)
-end
-
-# TSQuadratureND{D,T}(nlevels::Int) where {D,T<:Real} = TSQuadratureND{D,T}(TSQuadrature{T}(nlevels))
-import Base.eltype
-eltype(p::PointND{D,T}) where {D,T} = T
-eltype(q::TSQuadratureND{D,T}) where {D,T} = T
-eltype(l::LevelND{D,T}) where {D,T} = T
-
-# maps [a,b] to [-1,1] in 3D
-transform(u::AbstractVector{T}, a::AbstractVector{T}, b::AbstractVector{T}) where {T} = @. (b + a) / T(2) + ((b - a) / T(2)) * u
-
-function quadts(f, quad::TSQuadratureND{D,T}, xmin::SVector{D,T}, xmax::SVector{D,T}; atol::T=zero(T),
-                rtol::T=atol > 0 ? zero(T) : sqrt(eps(T))) where {D,T<:Real}
-    D::Int
-    @assert D ≥ 0
-
-    Δx = (xmax - xmin) / 2
-    h = quad.h # * Δx
-    x = (xmin + xmax) / 2
-    w = weight(zero(T))^D
-    s = prod(h) * w * f(x...)
-
-    levels = 0
-    error = T(Inf) #norm(typeof(s)(Inf))
-    for level in quad.levels
-        h /= 2
-        levels += 1
-        sold = s
-
-        s = zero(sold)
-        for p in level.points
-            t = zero(sold)
-            for i in CartesianIndex(ntuple(d -> -1, D)):CartesianIndex(ntuple(d -> 2, D)):CartesianIndex(ntuple(d -> +1, D))
-                xm = transform(-p.x, xmin, xmax)
-                xp = transform(p.x, xmin, xmax)
-                x = SVector{D,T}(Tuple(i)[d] < 0 ? xm[d] : xp[d] for d in 1:D)
-                t += f(x...)
-            end
-            # p.w = w1*w2*w3...
-            s += p.w * t
-        end
-        # shouldn't sold/2^D?
-        s = h^D * s + sold / 2
-
-        tol = max(norm(s) * rtol, atol)
-        error = norm(s - sold)
-        levels ≥ 1 && error ≤ tol && break
+function quadts(f, quad::TSQuadrature{T}, xmin::Real, xmax::Real; atol::T=zero(T),
+                rtol::T=atol > 0 ? zero(T) : sqrt(eps(T))) where {T<:Real}
+    if xmin == xmax
+        return (zero(T), zero(T), 0)
     end
 
-    return (result=prod(Δx) * s, error=error, levels=levels)
+    if xmin > xmax
+        res, err, lvls = _quadts(f, quad, xmax, xmin; atol=atol, rtol=rtol)
+        return (-res, err, lvls)
+    end
+
+    if xmin == -1 && xmax == 1
+        return _quadts(f, quad; atol=atol, rtol=rtol)
+    else
+        s = (xmax + xmin) / 2
+        t = (xmax - xmin) / 2
+        res, err, lvls = _quadts(u -> f(s + t * u), quad; atol=atol / t, rtol=rtol)
+        return (res * t, err * t, lvls)
+    end
 end
 
-export myquad2, myquad3
-function myquad3(f, quad::TSQuadrature{T}, xmin::AbstractVector{T}, xmax::AbstractVector{T}) where {T<:Real}
-    f1(x, y) = quadts(z -> f(x, y, z), quad, xmin[3], xmax[3])[1]
-    f2(x) = quadts(y -> f1(x, y), quad, xmin[2], xmax[2])[1]
-    f3() = quadts(x -> f2(x), quad, xmin[1], xmax[1])[1]
+## what happens with the error in the 3D case?
+function quadts(f, quad::TSQuadrature{T}, xmin::SVector{3,T}, xmax::SVector{3,T}; atol::T=zero(T),
+                rtol::T=atol > 0 ? zero(T) : sqrt(eps(T))) where {T<:Real}
+    f1(x, y) = quadts(z -> f(x, y, z), quad, xmin[3], xmax[3]; atol=atol, rtol=rtol)[1]
+    f2(x) = quadts(y -> f1(x, y), quad, xmin[2], xmax[2]; atol=atol, rtol=rtol)[1]
+    f3() = quadts(x -> f2(x), quad, xmin[1], xmax[1]; atol=atol, rtol=rtol)[1]
     return f3()
 end
 
-function myquad2(f, quad, xmin, xmax)
+function quadts(f, quad::TSQuadrature{T}, xmin::SVector{2,T}, xmax::SVector{2,T}; atol::T=zero(T),
+                rtol::T=atol > 0 ? zero(T) : sqrt(eps(T))) where {T<:Real}
     f2(x) = quadts(y -> f(x, y), quad, xmin[2], xmax[2])[1]
     f3() = quadts(x -> f2(x), quad, xmin[1], xmax[1])[1]
     return f3()
 end
 
-function quadts(f, quad::TSQuadratureND{D,T}, xmin::AbstractVector{<:Real}, xmax::AbstractVector{<:Real};
-                atol::Real=zero(T), rtol::Real=atol > 0 ? zero(T) : sqrt(eps(T))) where {D,T<:Real}
-    return quadts(f, quad, SVector{D,T}(xmin), SVector{D,T}(xmax); atol=atol, rtol=rtol)
+function quadts(f, quad::TSQuadrature{T}, xmin::AbstractVector{<:Real}, xmax::AbstractVector{<:Real}; atol::T=zero(T),
+                rtol::T=atol > 0 ? zero(T) : sqrt(eps(T))) where {T<:Real}
+    n = length(xmin)
+    return quadts(f, quad, SVector{n,T}(xmin), SVector{n,T}(xmax); atol=atol, rtol=rtol)
 end
 
-function quadts(f, quad::TSQuadratureND{D,T}, xmin::Union{NTuple{D},SVector{D}}, xmax::Union{NTuple{D},SVector{D}};
-                atol::Real=zero(T), rtol::Real=atol > 0 ? zero(T) : sqrt(eps(T))) where {D,T<:Real}
-    return quadts(f, quad, SVector{D,T}(xmin), SVector{D,T}(xmax); atol=atol, rtol=rtol)
-end
+# # maps [a,b] to [-1,1]
+# transform(u::T, a::T, b::T) where {T} = (b + a) / T(2) + ((b - a) / T(2)) * u
+
+# function quadts(f, quad::TSQuadratureND{D,T}, xmin::AbstractVector{<:Real}, xmax::AbstractVector{<:Real};
+#                 atol::Real=zero(T), rtol::Real=atol > 0 ? zero(T) : sqrt(eps(T))) where {D,T<:Real}
+#     return quadts(f, quad, SVector{D,T}(xmin), SVector{D,T}(xmax); atol=atol, rtol=rtol)
+# end
+
+# function quadts(f, quad::TSQuadratureND{D,T}, xmin::Union{NTuple{D},SVector{D}}, xmax::Union{NTuple{D},SVector{D}};
+#                 atol::Real=zero(T), rtol::Real=atol > 0 ? zero(T) : sqrt(eps(T))) where {D,T<:Real}
+#     return quadts(f, quad, SVector{D,T}(xmin), SVector{D,T}(xmax); atol=atol, rtol=rtol)
+# end
+
+## TSQuadratureND{D,T}(nlevels::Int) where {D,T<:Real} = TSQuadratureND{D,T}(TSQuadrature{T}(nlevels))
+# import Base.eltype
+# eltype(p::PointND{D,T}) where {D,T} = T
+# eltype(q::TSQuadratureND{D,T}) where {D,T} = T
+# eltype(l::LevelND{D,T}) where {D,T} = T
+
+# # maps [a,b] to [-1,1] in 3D
+# transform(u::AbstractVector{T}, a::AbstractVector{T}, b::AbstractVector{T}) where {T} = @. (b + a) / T(2) + ((b - a) / T(2)) * u
+
+# function _quadts(f, quad::TSQuadratureND{D,T}, xmin::SVector{D,T}, xmax::SVector{D,T}; atol::T=zero(T),
+#                  rtol::T=atol > 0 ? zero(T) : sqrt(eps(T))) where {D,T<:Real}
+#     D::Int
+#     @assert D ≥ 0
+
+#     Δx = (xmax - xmin) / 2
+#     h = quad.h # * Δx
+#     x = (xmin + xmax) / 2
+#     w = weight(zero(T))^D
+#     s = prod(h) * w * f(x...)
+
+#     levels = 0
+#     error = T(Inf) #norm(typeof(s)(Inf))
+#     for level in quad.levels
+#         h /= 2
+#         levels += 1
+#         sold = s
+
+#         s = zero(sold)
+#         for p in level.points
+#             t = zero(sold)
+#             for i in CartesianIndex(ntuple(d -> -1, D)):CartesianIndex(ntuple(d -> 2, D)):CartesianIndex(ntuple(d -> +1, D))
+#                 xm = transform(-p.x, xmin, xmax)
+#                 xp = transform(p.x, xmin, xmax)
+#                 x = SVector{D,T}(Tuple(i)[d] < 0 ? xm[d] : xp[d] for d in 1:D)
+#                 t += f(x...)
+#             end
+#             # p.w = w1*w2*w3...
+#             s += p.w * t
+#         end
+#         # shouldn't sold/2^D?
+#         s = h^D * s + sold / 2
+
+#         tol = max(norm(s) * rtol, atol)
+#         error = norm(s - sold)
+#         levels ≥ 1 && error ≤ tol && break
+#     end
+
+#     return (result=prod(Δx) * s, error=error, levels=levels)
+# end
+
+# #if I add type in constructor, julia doesn't see the whole function, why?
+# function TSQuadratureND{D,T}(nlevels::Int, p::Int=1) where {D,T<:Real}
+#     D::Int #why ?
+#     @assert D ≥ 0
+
+#     h = find_tmaxND(D, T, p)
+#     levels = Level{T}[]
+#     for level in 1:nlevels
+#         push!(levels, Level(h / 2^level, level))
+#     end
+#     quad = TSQuadrature{T}(h, levels)
+#     levels = LevelND{D,T}[]
+#     for level in 1:nlevels
+#         push!(levels, LevelND{D,T}(quad.levels[level]))
+#         npoints = length(levels[end].points)
+#     end
+#     return TSQuadratureND{D,T}(h, levels)
+# end
+
+# export TSQuadratureND
+
+# # An integration point, defined by its coordinate `x` and weight `w`
+# struct PointND{D,T}
+#     x::SVector{D,T}
+#     w::T
+# end
+
+# # We integrate in levels. Each successivel level refines the previous
+# # one, and only contains the additional points and weights.
+# struct LevelND{D,T}
+#     points::Vector{PointND{D,T}}
+# end
+
+# # A complete quadrature scheme. `h` is the base step size for level 0.
+# struct TSQuadratureND{D,T}
+#     h::T
+#     levels::Vector{LevelND{D,T}}
+# end
+
+# # is w ≠ 0 ok?
+# function LevelND{D,T}(level::Level{T}) where {D,T<:Real}
+#     D::Int
+#     @assert D ≥ 0
+#     points = PointND{D,T}[]
+#     npoints = length(level.points)
+#     for i in CartesianIndex(ntuple(d -> 1, D)):CartesianIndex(ntuple(d -> npoints, D))
+#         x = SVector{D,T}(level.points[Tuple(i)[d]].x for d in 1:D)
+#         w = prod(level.points[Tuple(i)[d]].w for d in 1:D)
+#         # w ≠ 0 && push!(points, PointND{D,T}(x, w))
+#         push!(points, PointND{D,T}(x, w))
+#     end
+#     return LevelND{D,T}(points)
+# end
 
 end


### PR DESCRIPTION
As described in https://arxiv.org/pdf/2007.15057.pdf the domain integration and the step size play a crucial role. I use their conditions with eps(::Type) to derive integration limits
and for the step size I adopted the maximal step size and not the optimal one, since the optimal stepsize can produce integration limits with instabilities from underflow.

This pr also gives support to higher powers of t in the base transformation 
such as shown in Eq. (4.3) of https://ems.press/content/serial-article-files/2719.